### PR TITLE
Added a MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include *.md
+include *.txt
+include .travis.yml
+recursive-include doc *.py
+recursive-include doc *.rst
+recursive-include doc Makefile
+recursive-include tests *.py


### PR DESCRIPTION
The pypi release is broken because of a missing README.md
Adding a proper MANIFEST.in fixes it
