### PR TITLE
Fix difference with single matching end.

### DIFF
--- a/pyinter/interval.py
+++ b/pyinter/interval.py
@@ -247,8 +247,14 @@ class Interval(object):
         If the `other` interval is enclosed in this one then this will return a
         :class:`~pyinter.IntervalSet`, otherwise this returns a :class:`~pyinter.Interval`.
         """
+        if other.empty():
+            return self
         if self in other:
             return open(0, 0)
+        if self._lower == other._lower and self._lower_value == other._lower_value:
+            return Interval(self._opposite_boundary_type(other._upper), other._upper_value, self._upper_value, self._upper)
+        if self._upper == other._upper and self._upper_value == other._upper_value:
+            return Interval(self._lower, self._lower_value, other._lower_value, self._opposite_boundary_type(other._lower))
         if other in self:
             return IntervalSet([
                 Interval(self._lower, self._lower_value, other.lower_value, self._opposite_boundary_type(other._lower)),

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -85,6 +85,20 @@ def test_subtract_overlapping():
     assert left - right == expected
 
 
+def test_subtract_overlapping_start():
+    left  = i.open(1, 10)
+    right = i.open(1, 5)
+    expected = i.closedopen(5, 10)
+    assert left - right == expected
+
+
+def test_subtract_overlapping_end():
+    left  = i.open(1, 10)
+    right = i.open(5, 10)
+    expected = i.openclosed(1, 5)
+    assert left - right == expected
+
+
 def test_subtract_contained():
     left = i.open(3, 6)
     right = i.open(4, 5)


### PR DESCRIPTION
Somehow this got missed when merging #11. This was a fix I make after the initial PR, you had probably already pulled your local branch. It fixes when the `other` interval is contained in the `self` but has a matching end.