### PR TITLE
Make empty interval contain same types as source interval.

### DIFF
--- a/pyinter/interval.py
+++ b/pyinter/interval.py
@@ -250,7 +250,7 @@ class Interval(object):
         if other.empty():
             return self
         if self in other:
-            return open(0, 0)
+            return open(self._lower_value, self._lower_value)
         if self._lower == other._lower and self._lower_value == other._lower_value:
             return Interval(self._opposite_boundary_type(other._upper), other._upper_value, self._upper_value, self._upper)
         if self._upper == other._upper and self._upper_value == other._upper_value:

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import pytest
 from pyinter import interval as i
 from pyinter import IntervalSet
@@ -112,6 +113,15 @@ def test_subtract_exact_overlap():
     assert (left - right).empty()
 
 
+def test_subtract_empty_types():
+    left  = i.closed(datetime(2015, 1, 1), datetime(2020, 1, 1))
+    right = i.closed(datetime(2010, 1, 1), datetime(2100, 1, 1))
+    result = left - right
+    assert result.empty()
+    assert isinstance(result.lower_value, datetime)
+    assert isinstance(result.upper_value, datetime)
+
+
 def test_subtract_almost_complete_overlap():
     left = i.closed(1, 2)
     right = i.open(1, 5)
@@ -134,8 +144,7 @@ def test_subtract_empty_from_empty_is_empty():
 def test_subtract_complete_overlap_returns_an_empty_interval():
     left = i.closed(1, 2)
     right = i.closed(1, 2)
-    expected = i.open(0, 0)
-    assert left - right == expected
+    assert (left - right).empty()
 
 
 def test_complement_open():


### PR DESCRIPTION
Otherwise they can't always be used as comparisons between the types
will be invalid.