### PR TITLE
The interval of 2 identical numbers equals the empty set if one of the boundaries is open

### DIFF
--- a/pyinter/interval.py
+++ b/pyinter/interval.py
@@ -198,8 +198,7 @@ class Interval(object):
     
     def empty(self):
         return (self._lower_value >= self._upper_value and
-                self._lower == self.OPEN and
-                self._upper == self.OPEN)
+               (self._lower == self.OPEN or self._upper == self.OPEN))
 
     def overlaps(self, other):
         """If self and other have any overlaping values returns True, otherwise returns False"""

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -122,9 +122,10 @@ def test_subtract_almost_complete_overlap():
 def test_empty():
     assert i.open(1, 1).empty()
     assert i.open(3, 3).empty()
+    assert i.openclosed(3, 3).empty()
+    assert i.closedopen(3, 3).empty()
     assert not i.open(3, 4).empty()
-    assert not i.openclosed(3, 3).empty()
-    assert not i.closedopen(3, 3).empty()
+    assert not i.openclosed(3, 4).empty()
 
 
 def test_subtract_empty_from_empty_is_empty():
@@ -162,9 +163,7 @@ def test_complement_empty():
 
 def test_complement_whole():
     whole = i.open(i.NEGATIVE_INFINITY, i.INFINITY)
-    (lower_interval, upper_interval) = sorted(whole.complement())  # an IntervalSet is not sorted
-    assert lower_interval == i.openclosed(i.NEGATIVE_INFINITY, i.NEGATIVE_INFINITY)
-    assert upper_interval == i.closedopen(i.INFINITY, i.INFINITY)
+    assert whole.complement().empty()
 
 
 def test_repr():


### PR DESCRIPTION
 openclosed(1,1) -> {}
 closedopen(1,1) -> {}

This change of logic required a big change in the test that validated the complement of the whole set, which is now just straight up empty, which is correct, but deviant from the old API.

@intiocean what do you think?

c.c @kevincox
