### PR TITLE
Update README: python-intervals has been renamed to "portion"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Note: This library is no longer maintained
 ------------------------------------------
 
-I recommend using the newer `python-intervals <https://github.com/AlexandreDecan/python-intervals>`_ library instead
+I recommend using the newer `portion <https://github.com/AlexandreDecan/portion>`_ library instead
 
 
 =======


### PR DESCRIPTION
Hello,

First of all, thank you for suggesting `python-intervals` as an alternative to `pyinter`! I submit this PR since I recently (for version 2.0.0) renamed `python-intervals` to `portion` because it led to some confusion with existing libraries (namely `intervals`). 

